### PR TITLE
Change the default font resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ const fontName = findFontName({
 console.log(fontName); // "Helvetica-Oblique"
 ```
 
+:warning: Caveats:
+
+- If the `fontFamily` property is missing, or the requested font is not installed, it will fall back to the default system
+  provided by the OS (usually, something from the _San Francisco_ family). The specific font returned changes across
+  macOS versions and for different font sizes.
+
 ### `createStringMeasurer`
 
 ```js
@@ -47,6 +53,14 @@ const size = createStringMeasurer(
 
 console.log(size); // "{ width: ..., height: ... }"
 ```
+
+:warning: Caveats:
+
+- When the `lineHeight` property is not specified, the default used by this function may be different from what Sketch
+  uses by default for certain font families. This might result in a bounding box calculation that is different from
+  what Sketch would display. For best results, it's advised to always specify the `lineHeight` explicitly.
+- Support for `textTransform` property is missing at the moment. When specified, the requested text transformation
+  will not be taken into account when computing the bounding box.
 
 ### `makeImageDataFromURL`
 

--- a/main.m
+++ b/main.m
@@ -159,7 +159,6 @@ NSFont *find_font(TextStyle *textStyle) {
             isItalic = textStyle->includesFontStyle ? isItalic : is_italic_font(font);
             isCondensed = is_condensed_font(font);
         } else {
-            NSLog(@"Unrecognized font family %@", fontFamily);
             font = [NSFont systemFontOfSize:textStyle->fontSize weight:fontWeight];
         }
     }
@@ -365,9 +364,6 @@ TextStyle *make_text_style(napi_env env, napi_value object) {
         napi_get_named_property(env, object, "fontFamily", &fontFamilyValue);
         NSString *fontFamilyString = ns_string_from_napi_value(env, fontFamilyValue);
         textStyle->fontFamily = fontFamilyString;
-    // Default to Helvetica if fonts are missing
-    } else if ([DEFAULT_FONT_FAMILY isEqualToString:APPLE_BROKEN_SYSTEM_FONT]) {
-        textStyle->fontFamily = @"Helvetica";
     } else {
         textStyle->fontFamily = DEFAULT_FONT_FAMILY;
     }

--- a/tests/findFontName.test.js
+++ b/tests/findFontName.test.js
@@ -45,21 +45,23 @@ describe("findFontName()", () => {
   });
 
   describe("missing fonts default to the system font", () => {
-    testEach([[{ fontFamily: "MissingFont" }, /^\.SFNS\w*(-Regular)?$/]]);
+    testEach([
+      [{ fontFamily: "MissingFont" }, /^\.SFNS\w*(-Regular)?$/],
+      [{ fontFamily: "MissingFont", fontWeight: "bold" }, /^\.SFNS\w*-Bold$/]
+    ]);
   });
 
   describe("when the fontFamily property is missing", () => {
-    // TODO(lordofthelake): Does this make sense, considering the missing font case?
-    // Shouldn't it default to the system font?
-    it("defaults to Helvetica", () => {
-      expect(findFontName({})).toEqual("Helvetica");
+    it("defaults to the system font", () => {
+      expect(findFontName({})).toMatch(/^\.SFNS\w*(-Regular)?$/);
+      expect(findFontName({ fontWeight: "bold" })).toMatch(/^\.SFNS\w*-Bold$/);
     });
   });
 
   describe("when the fontFamily property is blank", () => {
-    // TODO(lordofthelake): Coherence problem as above.
     it("defaults to the system font", () => {
       expect(findFontName({ fontFamily: "" })).toMatch(/^\.SFNS\w*(-Regular)?$/);
+      expect(findFontName({ fontFamily: "", fontWeight: "bold" })).toMatch(/^\.SFNS\w*-Bold$/);
     });
   });
 


### PR DESCRIPTION
Following up on what discussed in #6, this PR changes the behavior of the font resolution method, always falling back to the system font when the `fontFamily` is missing or not specified. I added some remarks in the `README` to document the behavior.